### PR TITLE
Add live Markdown formatting in note editor

### DIFF
--- a/NoteApp/MarkdownParser.swift
+++ b/NoteApp/MarkdownParser.swift
@@ -1,0 +1,88 @@
+import Foundation
+import UIKit
+
+struct MarkdownParser {
+    static func parse(_ text: String) -> NSAttributedString {
+        let attr = NSMutableAttributedString(string: text)
+        let fullRange = NSRange(location: 0, length: attr.length)
+        let bodyFont = UIFont.preferredFont(forTextStyle: .body)
+        attr.addAttribute(.font, value: bodyFont, range: fullRange)
+
+        applyHeading(pattern: "^###\\s+(.+)$", font: UIFont.preferredFont(forTextStyle: .title3), attr: attr)
+        applyHeading(pattern: "^##\\s+(.+)$", font: UIFont.preferredFont(forTextStyle: .title2), attr: attr)
+        applyHeading(pattern: "^#\\s+(.+)$", font: UIFont.preferredFont(forTextStyle: .title1), attr: attr)
+
+        applyList(pattern: "^(\\d+)\\.\\s+(.+)$", ordered: true, attr: attr)
+        applyList(pattern: "^[-\\*]\\s+(.+)$", ordered: false, attr: attr)
+
+        applyBlockquote(pattern: "^>\\s+(.+)$", attr: attr)
+
+        applyRegex(pattern: "\\*\\*(.+?)\\*\\*", markerLength: 2, attributes: [.font: UIFont.boldSystemFont(ofSize: bodyFont.pointSize)], attr: attr)
+        applyRegex(pattern: "\\*(.+?)\\*", markerLength: 1, attributes: [.font: UIFont.italicSystemFont(ofSize: bodyFont.pointSize)], attr: attr)
+        applyRegex(pattern: "__([^_]+?)__", markerLength: 2, attributes: [.underlineStyle: NSUnderlineStyle.single.rawValue], attr: attr)
+        applyRegex(pattern: "~~([^~]+?)~~", markerLength: 2, attributes: [.strikethroughStyle: NSUnderlineStyle.single.rawValue], attr: attr)
+        applyRegex(pattern: "`([^`]+?)`", markerLength: 1, attributes: [
+            .font: UIFont.monospacedSystemFont(ofSize: bodyFont.pointSize, weight: .regular),
+            .backgroundColor: UIColor.systemGray5
+        ], attr: attr)
+
+        applyHorizontalRule(pattern: "^---+$", attr: attr)
+
+        return attr
+    }
+
+    private static func applyRegex(pattern: String, markerLength: Int, attributes: [NSAttributedString.Key: Any], attr: NSMutableAttributedString) {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return }
+        let matches = regex.matches(in: attr.string, options: [], range: NSRange(location: 0, length: attr.length)).reversed()
+        for match in matches {
+            attr.addAttributes(attributes, range: match.range(at: 1))
+            attr.deleteCharacters(in: NSRange(location: match.range.location + match.range.length - markerLength, length: markerLength))
+            attr.deleteCharacters(in: NSRange(location: match.range.location, length: markerLength))
+        }
+    }
+
+    private static func applyHeading(pattern: String, font: UIFont, attr: NSMutableAttributedString) {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines]) else { return }
+        let matches = regex.matches(in: attr.string, options: [], range: NSRange(location: 0, length: attr.length)).reversed()
+        for match in matches {
+            attr.addAttribute(.font, value: font, range: match.range(at: 1))
+            attr.deleteCharacters(in: NSRange(location: match.range.location, length: match.range.length - match.range(at: 1).length))
+        }
+    }
+
+    private static func applyList(pattern: String, ordered: Bool, attr: NSMutableAttributedString) {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines]) else { return }
+        let matches = regex.matches(in: attr.string, options: [], range: NSRange(location: 0, length: attr.length)).reversed()
+        for match in matches {
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.headIndent = 20
+            let range = match.range(at: 0)
+            attr.addAttribute(.paragraphStyle, value: paragraph, range: range)
+            if !ordered {
+                attr.replaceCharacters(in: match.range(at: 0), with: "• " + (attr.string as NSString).substring(with: match.range(at: 1)))
+            }
+        }
+    }
+
+    private static func applyBlockquote(pattern: String, attr: NSMutableAttributedString) {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines]) else { return }
+        let matches = regex.matches(in: attr.string, options: [], range: NSRange(location: 0, length: attr.length)).reversed()
+        for match in matches {
+            let range = match.range(at: 1)
+            attr.addAttributes([
+                .foregroundColor: UIColor.systemGray,
+                .font: UIFont.italicSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize)
+            ], range: range)
+            attr.deleteCharacters(in: NSRange(location: match.range.location, length: 2))
+        }
+    }
+
+    private static func applyHorizontalRule(pattern: String, attr: NSMutableAttributedString) {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines]) else { return }
+        let matches = regex.matches(in: attr.string, options: [], range: NSRange(location: 0, length: attr.length)).reversed()
+        for match in matches {
+            let line = String(repeating: "\u{2015}", count: 20)
+            attr.replaceCharacters(in: match.range, with: "\n" + line + "\n")
+        }
+    }
+}

--- a/NoteApp/MarkdownTextView.swift
+++ b/NoteApp/MarkdownTextView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import UIKit
+
+struct MarkdownTextView: UIViewRepresentable {
+    @Binding var text: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.delegate = context.coordinator
+        textView.isScrollEnabled = true
+        textView.backgroundColor = .clear
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        DispatchQueue.main.async {
+            textView.becomeFirstResponder()
+        }
+        return textView
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        if uiView.text != text {
+            uiView.text = text
+        }
+        context.coordinator.format(textView: uiView)
+    }
+
+    class Coordinator: NSObject, UITextViewDelegate {
+        var parent: MarkdownTextView
+        private var workItem: DispatchWorkItem?
+
+        init(_ parent: MarkdownTextView) {
+            self.parent = parent
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            parent.text = textView.text
+            scheduleFormatting(textView)
+        }
+
+        private func scheduleFormatting(_ textView: UITextView) {
+            workItem?.cancel()
+            let item = DispatchWorkItem { [weak textView] in
+                guard let tv = textView else { return }
+                let formatted = MarkdownParser.parse(tv.text)
+                DispatchQueue.main.async {
+                    let selected = tv.selectedRange
+                    tv.attributedText = formatted
+                    tv.selectedRange = selected
+                }
+            }
+            workItem = item
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.1, execute: item)
+        }
+
+        func format(textView: UITextView) {
+            let formatted = MarkdownParser.parse(textView.text)
+            textView.attributedText = formatted
+        }
+    }
+}

--- a/NoteApp/NoteEditorView.swift
+++ b/NoteApp/NoteEditorView.swift
@@ -4,8 +4,6 @@ import SwiftData
 struct NoteEditorView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss)     private var dismiss
-    @FocusState private var focusedField: Bool
-
     @State private var noteContent: String
     private let noteToEdit: Note?
 
@@ -30,11 +28,8 @@ struct NoteEditorView: View {
                 .padding(.top, 16)
 
                 // Editor
-                TextEditor(text: $noteContent)
-                    .focused($focusedField)
-                    .onAppear { focusedField = true }
-                    .font(.body)
-                    .padding(.horizontal,0)
+                MarkdownTextView(text: $noteContent)
+                    .padding(.horizontal, 0)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             }


### PR DESCRIPTION
## Summary
- replace plain TextEditor with MarkdownTextView for live formatted editing
- parse common markdown symbols into attributed text using regex
- debounce formatting on background thread for responsive typing

## Testing
- `xcodebuild test -scheme NoteApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689975a5fa4083239f1ae8c3a7ff7b0b